### PR TITLE
Implemented timeout for interop calls.

### DIFF
--- a/Blazorade.Core/Blazorade.Core.xml
+++ b/Blazorade.Core/Blazorade.Core.xml
@@ -367,15 +367,20 @@
             This method supports the functionality provided by the class and should not be used in your code.
             </remarks>
         </member>
-        <member name="M:Blazorade.Core.Interop.DotNetInstanceCallbackHandler`2.GetResultAsync">
+        <member name="M:Blazorade.Core.Interop.DotNetInstanceCallbackHandler`2.GetResultAsync(System.Int32)">
             <summary>
             Calls the JavaScript function specified when the class instance was created. The <see cref="T:System.Threading.Tasks.Task"/> returned
             by this method will complete when the called JavaScript function calls one of the callbacks sent as argument.
             </summary>
+            <param name="timeout">The timeout in milliseconds to wait for a call on either success or failure callbacks from the called JavaScript.</param>
             <exception cref="T:Blazorade.Core.Interop.FailureCallbackException">
             The exception that is thrown if your JavaScript code calls the <c>failureCallback</c> callback. The
             <see cref="P:Blazorade.Core.Interop.FailureCallbackException.Result"/> property will contain the argument that your JavaScript
             code send to the callback.
+            </exception>
+            <exception cref="T:Blazorade.Core.Interop.InteropTimeoutException">
+            The exception that is thrown if the method call times out, i.e. the called JavaScript has not called either success
+            or failure callbacks.
             </exception>
         </member>
         <member name="M:Blazorade.Core.Interop.DotNetInstanceCallbackHandler`2.Dispose">
@@ -525,6 +530,26 @@
         <member name="P:Blazorade.Core.Interop.FailureCallbackException.Result">
             <summary>
             The result that may contain additional information about the failure.
+            </summary>
+        </member>
+        <member name="T:Blazorade.Core.Interop.InteropTimeoutException">
+            <summary>
+            The exception that is used to signal timeouts with.
+            </summary>
+        </member>
+        <member name="M:Blazorade.Core.Interop.InteropTimeoutException.#ctor">
+            <summary>
+            Creates a new instance of the class.
+            </summary>
+        </member>
+        <member name="M:Blazorade.Core.Interop.InteropTimeoutException.#ctor(System.String)">
+            <summary>
+            Creates a new instance of the class.
+            </summary>
+        </member>
+        <member name="M:Blazorade.Core.Interop.InteropTimeoutException.#ctor(System.String,System.Exception)">
+            <summary>
+            Creates a new instance of the class.
             </summary>
         </member>
         <member name="T:Blazorade.Core.Services.BlazoradeInteropServiceBase">

--- a/Blazorade.Core/Interop/InteropTimeoutException.cs
+++ b/Blazorade.Core/Interop/InteropTimeoutException.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorade.Core.Interop
+{
+    /// <summary>
+    /// The exception that is used to signal timeouts with.
+    /// </summary>
+    public class InteropTimeoutException : Exception
+    {
+        /// <summary>
+        /// Creates a new instance of the class.
+        /// </summary>
+        public InteropTimeoutException() { }
+
+        /// <summary>
+        /// Creates a new instance of the class.
+        /// </summary>
+        public InteropTimeoutException(string message) : base(message) { }
+
+        /// <summary>
+        /// Creates a new instance of the class.
+        /// </summary>
+        public InteropTimeoutException(string message, Exception innerException) : base(message, innerException) { }
+
+    }
+}

--- a/ServerApp/Pages/Callbacks.razor
+++ b/ServerApp/Pages/Callbacks.razor
@@ -14,6 +14,12 @@
     [Parameter]
     public bool Error1Check { get; set; }
 
+    [Parameter]
+    public string TimeoutError { get; set; }
+
+    [Parameter]
+    public DateTime? TimeoutTimestamp { get; set; }
+
     private DotNetInstanceMethod Callback;
     [JSInvokable]
     public Task CallbackAsync(string data)
@@ -65,6 +71,27 @@
         }
     }
 
+    private async Task ClickHandlerWithTimeoutAsync(MouseEventArgs args)
+    {
+        this.TimeoutError = null;
+        this.TimeoutTimestamp = null;
+
+        var module = await this.GetJsModuleAsync();
+
+        using(var handler = new DotNetInstanceCallbackHandler(module, "devNull"))
+        {
+            try
+            {
+                await handler.GetResultAsync();
+            }
+            catch(Exception ex)
+            {
+                this.TimeoutTimestamp = DateTime.Now;
+                this.TimeoutError = ex.ToString();
+            }
+        }
+    }
+
     Task<IJSObjectReference> jsModule;
     private Task<IJSObjectReference> GetJsModuleAsync()
     {
@@ -110,3 +137,13 @@
 <p>
     <span>Data: @this.Data3</span>
 </p>
+
+<hr />
+
+<div>
+    <button @onclick="this.ClickHandlerWithTimeoutAsync">Invoke Timeout</button>
+</div>
+<ul>
+    <li>Timestamp: @this.TimeoutTimestamp</li>
+    <li>Timeout Error: @this.TimeoutError</li>
+</ul>

--- a/ServerApp/wwwroot/js/jsFuncs.js
+++ b/ServerApp/wwwroot/js/jsFuncs.js
@@ -20,3 +20,8 @@ export function getTimeStringOrError(args) {
         args.failureCallback.target.invokeMethodAsync(args.failureCallback.methodName);
     }
 }
+
+export function devNull(args) {
+    console.log("devNull", args);
+
+}


### PR DESCRIPTION
The default timeout is now 3000 ms, but can be specified when calling the `DotNetInstanceCallbackHandler.GetResultAsync` method.

Closes #9 